### PR TITLE
Bch pls be gone

### DIFF
--- a/config.js
+++ b/config.js
@@ -54,13 +54,7 @@ var config = {
         // Multiple servers (in priority order)
         // url: ['http://a.b.c', 'https://test-insight.bitpay.com:443'],
       },
-    },
-    bch: {
-      livenet: {
-        provider: 'insight',
-        url: 'https://bch-insight.bitpay.com',
-      },
-    },
+    }
   },
   pushNotificationsOpts: {
     templatePath: './lib/templates',

--- a/lib/blockchainexplorer.js
+++ b/lib/blockchainexplorer.js
@@ -17,9 +17,6 @@ var PROVIDERS = {
       'livenet': 'https://btcz.rocks:443',
       'testnet': 'https://test.btcz.rocks:443',
     },
-    'bch': {
-      'livenet': 'https://insight.bitpay.com:443',
-    },
   },
 };
 

--- a/lib/blockchainmonitor.js
+++ b/lib/blockchainmonitor.js
@@ -28,7 +28,6 @@ BlockchainMonitor.prototype.start = function(opts, cb) {
     function(done) {
       self.explorers = {
         btcz: {},
-        bch: {},
       };
 
       var coinNetworkPairs = [];

--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -4,7 +4,6 @@ var Constants = {};
 
 Constants.COINS = {
   BTC: 'btcz',
-  BCH: 'bch',
 };
 
 Constants.NETWORKS = {

--- a/lib/common/defaults.js
+++ b/lib/common/defaults.js
@@ -46,11 +46,6 @@ Defaults.FEE_LEVELS = {
     name: 'superEconomy',
     nbBlocks: 24,
     defaultValue: 20000
-  }],
-  bch: [{
-    name: 'normal',
-    nbBlocks: 2,
-    defaultValue: 2000,
   }]
 };
 
@@ -83,7 +78,7 @@ Defaults.UTXO_SELECTION_MAX_FEE_VS_SINGLE_UTXO_FEE_FACTOR = 5;
 // Minimum allowed amount for tx outputs (including change) in SAT
 Defaults.MIN_OUTPUT_AMOUNT = 5000;
 
-// Number of confirmations from which tx in history will be cached 
+// Number of confirmations from which tx in history will be cached
 // (ie we consider them inmutables)
 Defaults.CONFIRMATIONS_TO_START_CACHING = 6 * 6; // ~ 6hrs
 
@@ -102,14 +97,14 @@ Defaults.SESSION_EXPIRATION = 1 * 60 * 60; // 1 hour to session expiration
 
 Defaults.RateLimit = {
   createWallet: {
-    windowMs: 60 * 60 * 1000, // hour window 
-    delayAfter: 10, // begin slowing down responses after the 3rd request 
-    delayMs: 3000, // slow down subsequent responses by 3 seconds per request 
+    windowMs: 60 * 60 * 1000, // hour window
+    delayAfter: 10, // begin slowing down responses after the 3rd request
+    delayMs: 3000, // slow down subsequent responses by 3 seconds per request
     max: 20, // start blocking after 20 request
     message: "Too many wallets created from this IP, please try again after an hour"
   },
   // otherPosts: {
-  //   windowMs: 60 * 60 * 1000, // 1 hour window 
+  //   windowMs: 60 * 60 * 1000, // 1 hour window
   //   max: 1200 , // 1 post every 3 sec average, max.
   // },
 };

--- a/lib/common/utils.js
+++ b/lib/common/utils.js
@@ -9,8 +9,7 @@ var secp256k1 = require('secp256k1');
 var Utils = {};
 var Bitcore = require('bitcore-lib-btcz');
 var Bitcore_ = {
-  btcz: Bitcore,
-  bch: require('bitcore-lib-cash')
+  btcz: Bitcore
 };
 
 
@@ -112,11 +111,6 @@ Utils.formatAmount = function(satoshis, unit, opts) {
       toSatoshis: 1,
       maxDecimals: 0,
       minDecimals: 0,
-    },
-    bch: {
-      toSatoshis: 100000000,
-      maxDecimals: 6,
-      minDecimals: 2,
     },
   };
 

--- a/lib/emailservice.js
+++ b/lib/emailservice.js
@@ -222,7 +222,6 @@ EmailService.prototype._getDataForTemplate = function(notification, recipient, c
   var UNIT_LABELS = {
     btcz: 'BTCZ',
     bit: 'bits',
-    bch: 'BCH',
   };
 
   var data = _.cloneDeep(notification.data);

--- a/lib/model/address.js
+++ b/lib/model/address.js
@@ -4,8 +4,7 @@ var $ = require('preconditions').singleton();
 var _ = require('lodash');
 
 var Bitcore = {
-  'btcz': require('bitcore-lib-btcz'),
-  'bch': require('bitcore-lib-cash'),
+  'btcz': require('bitcore-lib-btcz')
 };
 var Common = require('../common');
 var Constants = Common.Constants,

--- a/lib/model/txproposal.js
+++ b/lib/model/txproposal.js
@@ -9,7 +9,6 @@ log.disableColor();
 
 var Bitcore = {
   'btcz': require('bitcore-lib-btcz'),
-  'bch': require('bitcore-lib-cash'),
 };
 
 var Common = require('../common');

--- a/lib/pushnotificationsservice.js
+++ b/lib/pushnotificationsservice.js
@@ -282,7 +282,6 @@ PushNotificationsService.prototype._getDataForTemplate = function(notification, 
   var UNIT_LABELS = {
     btcz: 'BTCZ',
     bit: 'bits',
-    bch: 'BCH',
   };
 
   var data = _.cloneDeep(notification.data);

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,8 +13,7 @@ var Stringify = require('json-stable-stringify');
 
 var Bitcore = require('bitcore-lib-btcz');
 var Bitcore_ = {
-  btcz: Bitcore,
-  bch: require('bitcore-lib-cash')
+  btcz: Bitcore
 };
 
 var Common = require('./common');
@@ -300,7 +299,7 @@ WalletService.prototype.logout = function(opts, cb) {
  * @param {number} opts.n - Total copayers.
  * @param {string} opts.pubKey - Public key to verify copayers joining have access to the wallet secret.
  * @param {string} opts.singleAddress[=false] - The wallet will only ever have one address.
- * @param {string} opts.coin[='btcz'] - The coin for this wallet (btc, bch).
+ * @param {string} opts.coin[='btcz'] - The coin for this wallet (btcz).
  * @param {string} opts.network[='livenet'] - The Bitcoin network for this wallet.
  * @param {string} opts.supportBIP44AndP2PKH[=true] - Client supports BIP44 & P2PKH for new wallets.
  */
@@ -755,7 +754,7 @@ WalletService._getCopayerHash = function(name, xPubKey, requestPubKey) {
  * Joins a wallet in creation.
  * @param {Object} opts
  * @param {string} opts.walletId - The wallet id.
- * @param {string} opts.coin[='btcz'] - The expected coin for this wallet (btc, bch).
+ * @param {string} opts.coin[='btcz'] - The expected coin for this wallet (btcz).
  * @param {string} opts.name - The copayer name.
  * @param {string} opts.xPubKey - Extended Public Key for this copayer.
  * @param {string} opts.requestPubKey - Public Key used to check requests from this copayer.
@@ -2759,10 +2758,6 @@ WalletService._initBlockchainHeightCache = function() {
   if (WalletService._cachedBlockheight) return;
   WalletService._cachedBlockheight = {
     btcz: {
-      livenet: {},
-      testnet: {}
-    },
-    bch: {
       livenet: {},
       testnet: {}
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "apicache": "^1.2.1",
     "async": "^0.9.2",
     "bitcore-lib-btcz": "https://github.com/bitcoinz-wallets/bitcore-lib-btcz.git#v1.0.0",
-    "bitcore-lib-cash": "https://github.com/bitpay/bitcore-lib.git#cash",
     "body-parser": "^1.11.0",
     "compression": "^1.6.2",
     "coveralls": "^2.11.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "apicache": "^1.2.1",
     "async": "^0.9.2",
-    "bitcore-lib-btcz": "https://github.com/bitcoinz-wallets/bitcore-lib-btcz.git#v1.0.0",
+    "bitcore-lib-btcz": "https://github.com/bitcoinz-wallets/bitcore-lib-btcz.git#v1.0.2",
     "body-parser": "^1.11.0",
     "compression": "^1.6.2",
     "coveralls": "^2.11.2",

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -14,8 +14,7 @@ var tingodb = require('tingodb')({
 
 var Bitcore = require('bitcore-lib-btcz');
 var Bitcore_ = {
-  btcz: Bitcore,
-  bch: require('bitcore-lib-cash')
+  btcz: Bitcore
 };
 
 var Common = require('../../lib/common');


### PR DESCRIPTION
It turns out BCH causes subtle compatibility issues in the bitcore wallet service. This commit removes BCH support completely as it is unnecessary and unsupported.